### PR TITLE
Feature/Novel-69: 작품 수정, 삭제 기능 추가

### DIFF
--- a/src/main/kotlin/com/novel/cloud/db/entity/artwork/Artwork.kt
+++ b/src/main/kotlin/com/novel/cloud/db/entity/artwork/Artwork.kt
@@ -43,6 +43,7 @@ class Artwork(
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     var artworkType: ArtworkType = artworkType
+        protected set
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(nullable = false)
@@ -98,6 +99,18 @@ class Artwork(
 
     fun addBookmark(bookmark: Bookmark) {
         mutableBookmarks.add(bookmark)
+    }
+
+    fun update(title: String, content: String, artworkType: ArtworkType, tags: List<Tag>) {
+        this.title = title
+        this.content = content
+        this.artworkType = artworkType
+        this.mutableTags.removeAll(this.tags)
+        this.mutableTags.addAll(tags)
+    }
+
+    fun removeAttachFiles() {
+        mutableAttachFiles.removeAll(attachFiles)
     }
 
 }

--- a/src/main/kotlin/com/novel/cloud/db/entity/artwork/Artwork.kt
+++ b/src/main/kotlin/com/novel/cloud/db/entity/artwork/Artwork.kt
@@ -59,7 +59,7 @@ class Artwork(
     protected val mutableTags: MutableList<Tag> = tags.toMutableList()
     val tags: List<Tag> get() = mutableTags.toList()
 
-    @OneToMany(fetch = FetchType.LAZY)
+    @OneToMany(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
     @JoinColumn(nullable = false)
     private val mutableComments: MutableList<Comment> = mutableListOf()
     val comments: List<Comment> get() = mutableComments.toList()
@@ -67,12 +67,12 @@ class Artwork(
     @Column(length = 200, nullable = true)
     var thumbnail: String? = null
 
-    @OneToMany(fetch = FetchType.LAZY)
+    @OneToMany(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
     @JoinColumn(nullable = false)
     private val mutableAttachFiles: MutableList<AttachFile> = mutableListOf()
     val attachFiles: List<AttachFile> get() = mutableAttachFiles.toList()
 
-    @OneToMany(fetch = FetchType.LAZY)
+    @OneToMany(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
     @JoinColumn(nullable = false)
     private val mutableBookmarks: MutableList<Bookmark> = mutableListOf()
     val bookmarks: List<Bookmark> get() = mutableBookmarks.toList()
@@ -107,10 +107,6 @@ class Artwork(
 
     fun addBookmark(bookmark: Bookmark) {
         mutableBookmarks.add(bookmark)
-    }
-
-    fun removeAttachFiles() {
-        mutableAttachFiles.removeAll(attachFiles)
     }
 
 }

--- a/src/main/kotlin/com/novel/cloud/db/entity/artwork/Artwork.kt
+++ b/src/main/kotlin/com/novel/cloud/db/entity/artwork/Artwork.kt
@@ -81,6 +81,14 @@ class Artwork(
         writer.writeArtwork(this)
     }
 
+    fun update(title: String, content: String, artworkType: ArtworkType, tags: List<Tag>) {
+        this.title = title
+        this.content = content
+        this.artworkType = artworkType
+        this.mutableTags.removeAll(this.tags)
+        this.mutableTags.addAll(tags)
+    }
+
     fun updateThumbnail(thumbnail: String) {
         this.thumbnail = thumbnail
     }
@@ -99,14 +107,6 @@ class Artwork(
 
     fun addBookmark(bookmark: Bookmark) {
         mutableBookmarks.add(bookmark)
-    }
-
-    fun update(title: String, content: String, artworkType: ArtworkType, tags: List<Tag>) {
-        this.title = title
-        this.content = content
-        this.artworkType = artworkType
-        this.mutableTags.removeAll(this.tags)
-        this.mutableTags.addAll(tags)
     }
 
     fun removeAttachFiles() {

--- a/src/main/kotlin/com/novel/cloud/db/entity/attach_file/AttachFile.kt
+++ b/src/main/kotlin/com/novel/cloud/db/entity/attach_file/AttachFile.kt
@@ -21,15 +21,15 @@ class AttachFile (
     attachFileType: AttachFileType
 ): BaseEntity() {
 
-    @Column(length = 200, nullable = false)
+    @Column(length = 400, nullable = false)
     var fileName: String = fileName
         protected set
 
-    @Column(length = 200, nullable = false)
+    @Column(length = 1000, nullable = false)
     var fileUidName: String = fileUidName
         protected set
 
-    @Column(length = 200, nullable = false)
+    @Column(length = 1000, nullable = false)
     var filePath: String = filePath
         protected set
 

--- a/src/main/kotlin/com/novel/cloud/db/entity/tag/Tag.kt
+++ b/src/main/kotlin/com/novel/cloud/db/entity/tag/Tag.kt
@@ -41,8 +41,12 @@ class Tag(
     var writer: Member = writer
         protected set
 
-    fun updateUsageCount() {
+    fun plusUsageCount() {
         usageCount++
+    }
+
+    fun minusUsageCount() {
+        usageCount--
     }
 
 }

--- a/src/main/kotlin/com/novel/cloud/web/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/novel/cloud/web/config/security/SecurityConfig.kt
@@ -34,9 +34,9 @@ class SecurityConfig(
         }
         authorizeRequests().apply {
             antMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**").permitAll()
-            antMatchers("/resources/**", "/").permitAll() // 에러 핸들러
-            antMatchers(ApiPath.ERROR_AUTH).permitAll() // 인증
-            antMatchers(ApiPath.LOGIN_OAUTH2).permitAll()
+            antMatchers("/resources/**", "/v1").permitAll()
+            antMatchers(ApiPath.ERROR_AUTH).permitAll() // 에러 핸들러
+            antMatchers(ApiPath.LOGIN_OAUTH2).permitAll() // 인증
             antMatchers(ApiPath.REFRESH_TOKEN).permitAll()
             antMatchers(ApiPath.VIEW_ARTWORK).permitAll() // 조회
             antMatchers(ApiPath.ARTWORK_DETAIL).permitAll()

--- a/src/main/kotlin/com/novel/cloud/web/config/swagger/Swagger2Config.kt
+++ b/src/main/kotlin/com/novel/cloud/web/config/swagger/Swagger2Config.kt
@@ -19,7 +19,7 @@ class Swagger2Config {
     fun publicApi(): GroupedOpenApi? {
         return GroupedOpenApi.builder()
             .group("v1-documentation")
-            .pathsToMatch("/api/**")
+            .pathsToMatch("/api/v1/**")
             .addOpenApiCustomiser(openApiCustomizer())
             .build()
     }

--- a/src/main/kotlin/com/novel/cloud/web/config/web/CorsPatternConstant.kt
+++ b/src/main/kotlin/com/novel/cloud/web/config/web/CorsPatternConstant.kt
@@ -6,7 +6,7 @@ object CorsPatternConstant {
 
     const val CORS_LOCAL_SWAGGER = "http*://10.150.151.237/:[*]"
 
-    const val CORS_PR = "http*://ec2-54-180-163-47.ap-northeast-2.compute.amazonaws.com"
+    const val CORS_PR = "http*://example.com"
 
     const val CORS_PR_FE = "http*://novel-cloud.kro.kr"
 

--- a/src/main/kotlin/com/novel/cloud/web/config/web/CorsPatternConstant.kt
+++ b/src/main/kotlin/com/novel/cloud/web/config/web/CorsPatternConstant.kt
@@ -4,7 +4,7 @@ object CorsPatternConstant {
 
     const val CORS_LOCAL = "http*://localhost:[*]"
 
-    const val CORS_LOCAL_SWAGGER = "http*://10.150.151.237/:[*]"
+    const val CORS_LOCAL_SWAGGER = "http*://192.168.11.250/:[*]"
 
     const val CORS_PR = "http*://example.com"
 

--- a/src/main/kotlin/com/novel/cloud/web/domain/artwork/controller/ArtworkController.kt
+++ b/src/main/kotlin/com/novel/cloud/web/domain/artwork/controller/ArtworkController.kt
@@ -3,6 +3,7 @@ package com.novel.cloud.web.domain.artwork.controller
 import com.novel.cloud.web.config.security.context.MemberContext
 import com.novel.cloud.web.domain.artwork.controller.rq.CreateArtworkRq
 import com.novel.cloud.web.domain.artwork.controller.rq.AutoSaveTemporaryArtworkRq
+import com.novel.cloud.web.domain.artwork.controller.rq.UpdateArtworkRq
 import com.novel.cloud.web.domain.artwork.controller.rq.UpdateArtworkViewRq
 import com.novel.cloud.web.domain.artwork.service.ArtworkService
 import com.novel.cloud.web.domain.file.service.FileService
@@ -45,6 +46,19 @@ class ArtworkController(
     ) {
         FileValidateUtils.supportedFileValidationCheck(files)
         val artwork = artworkService.submitArtwork(memberContext, rq)
+        fileService.uploadArtworkImage(memberContext, artwork, thumbnail, files)
+    }
+
+    @Operation(summary = "작품 수정")
+    @PostMapping(ApiPath.ARTWORK_UPDATE)
+    fun updateArtwork(
+        @AuthenticationPrincipal memberContext: MemberContext,
+        @Validated @RequestPart(value = "rq") rq: UpdateArtworkRq,
+        @RequestPart(value = "thumbnail") thumbnail: MultipartFile,
+        @RequestPart(value = "files") files: List<MultipartFile>,
+    ) {
+        FileValidateUtils.supportedFileValidationCheck(files)
+        val artwork = artworkService.updateArtwork(memberContext, rq)
         fileService.uploadArtworkImage(memberContext, artwork, thumbnail, files)
     }
 

--- a/src/main/kotlin/com/novel/cloud/web/domain/artwork/controller/ArtworkController.kt
+++ b/src/main/kotlin/com/novel/cloud/web/domain/artwork/controller/ArtworkController.kt
@@ -3,6 +3,7 @@ package com.novel.cloud.web.domain.artwork.controller
 import com.novel.cloud.web.config.security.context.MemberContext
 import com.novel.cloud.web.domain.artwork.controller.rq.CreateArtworkRq
 import com.novel.cloud.web.domain.artwork.controller.rq.AutoSaveTemporaryArtworkRq
+import com.novel.cloud.web.domain.artwork.controller.rq.DeleteArtworkRq
 import com.novel.cloud.web.domain.artwork.controller.rq.UpdateArtworkRq
 import com.novel.cloud.web.domain.artwork.controller.rq.UpdateArtworkViewRq
 import com.novel.cloud.web.domain.artwork.service.ArtworkService
@@ -13,7 +14,9 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController
@@ -50,7 +53,7 @@ class ArtworkController(
     }
 
     @Operation(summary = "작품 수정")
-    @PostMapping(ApiPath.ARTWORK_UPDATE)
+    @PutMapping(ApiPath.ARTWORK_UPDATE)
     fun updateArtwork(
         @AuthenticationPrincipal memberContext: MemberContext,
         @Validated @RequestPart(value = "rq") rq: UpdateArtworkRq,
@@ -62,8 +65,17 @@ class ArtworkController(
         fileService.updateArtworkImage(memberContext, artwork, thumbnail, files)
     }
 
+    @Operation(summary = "작품 삭제")
+    @DeleteMapping(ApiPath.ARTWORK_DELETE)
+    fun deleteArtwork(
+        @AuthenticationPrincipal memberContext: MemberContext,
+        @Validated @RequestBody rq: DeleteArtworkRq
+    ) {
+        artworkService.deleteArtwork(memberContext, rq)
+    }
+
     @Operation(summary = "조회수 증가")
-    @PostMapping(ApiPath.VIEW_ARTWORK)
+    @PutMapping(ApiPath.VIEW_ARTWORK)
     fun updateArtworkView(@Validated @RequestBody rq: UpdateArtworkViewRq) {
         artworkService.updateArtworkView(rq)
     }

--- a/src/main/kotlin/com/novel/cloud/web/domain/artwork/controller/ArtworkController.kt
+++ b/src/main/kotlin/com/novel/cloud/web/domain/artwork/controller/ArtworkController.kt
@@ -59,7 +59,7 @@ class ArtworkController(
     ) {
         FileValidateUtils.supportedFileValidationCheck(files)
         val artwork = artworkService.updateArtwork(memberContext, rq)
-        fileService.uploadArtworkImage(memberContext, artwork, thumbnail, files)
+        fileService.updateArtworkImage(memberContext, artwork, thumbnail, files)
     }
 
     @Operation(summary = "조회수 증가")

--- a/src/main/kotlin/com/novel/cloud/web/domain/artwork/controller/ArtworkController.kt
+++ b/src/main/kotlin/com/novel/cloud/web/domain/artwork/controller/ArtworkController.kt
@@ -47,7 +47,7 @@ class ArtworkController(
         @RequestPart(value = "thumbnail") thumbnail: MultipartFile,
         @RequestPart(value = "files") files: List<MultipartFile>,
     ) {
-        FileValidateUtils.supportedFileValidationCheck(files)
+        FileValidateUtils.imageValidationCheck(files)
         val artwork = artworkService.submitArtwork(memberContext, rq)
         fileService.uploadArtworkImage(memberContext, artwork, thumbnail, files)
     }
@@ -60,7 +60,7 @@ class ArtworkController(
         @RequestPart(value = "thumbnail") thumbnail: MultipartFile,
         @RequestPart(value = "files") files: List<MultipartFile>,
     ) {
-        FileValidateUtils.supportedFileValidationCheck(files)
+        FileValidateUtils.imageValidationCheck(files)
         val artwork = artworkService.updateArtwork(memberContext, rq)
         fileService.updateArtworkImage(memberContext, artwork, thumbnail, files)
     }

--- a/src/main/kotlin/com/novel/cloud/web/domain/artwork/controller/ArtworkController.kt
+++ b/src/main/kotlin/com/novel/cloud/web/domain/artwork/controller/ArtworkController.kt
@@ -44,12 +44,17 @@ class ArtworkController(
     fun submitArtwork(
         @AuthenticationPrincipal memberContext: MemberContext,
         @Validated @RequestPart(value = "rq") rq: CreateArtworkRq,
-        @RequestPart(value = "thumbnail") thumbnail: MultipartFile,
-        @RequestPart(value = "files") files: List<MultipartFile>,
+        @RequestPart(value = "thumbnail", required = false) thumbnail: MultipartFile?,
+        @RequestPart(value = "files", required = false) files: List<MultipartFile>?,
     ) {
-        FileValidateUtils.imageValidationCheck(files)
         val artwork = artworkService.submitArtwork(memberContext, rq)
-        fileService.uploadArtworkImage(memberContext, artwork, thumbnail, files)
+        // TODO::refactoring
+        thumbnail?.let {
+            files?.let {
+                FileValidateUtils.imageValidationCheck(files)
+                fileService.uploadArtworkImage(memberContext, artwork, thumbnail, files)
+            }
+        }
     }
 
     @Operation(summary = "작품 수정")

--- a/src/main/kotlin/com/novel/cloud/web/domain/artwork/controller/rq/DeleteArtworkRq.kt
+++ b/src/main/kotlin/com/novel/cloud/web/domain/artwork/controller/rq/DeleteArtworkRq.kt
@@ -1,0 +1,10 @@
+package com.novel.cloud.web.domain.artwork.controller.rq
+
+import javax.validation.constraints.NotNull
+
+data class DeleteArtworkRq (
+
+    @field:NotNull
+    val artworkId: Long
+
+)

--- a/src/main/kotlin/com/novel/cloud/web/domain/artwork/controller/rq/UpdateArtworkRq.kt
+++ b/src/main/kotlin/com/novel/cloud/web/domain/artwork/controller/rq/UpdateArtworkRq.kt
@@ -1,0 +1,24 @@
+package com.novel.cloud.web.domain.artwork.controller.rq
+
+import com.novel.cloud.db.enums.ArtworkType
+import javax.validation.constraints.NotEmpty
+import javax.validation.constraints.NotNull
+
+data class UpdateArtworkRq (
+
+    @field:NotNull
+    val artworkId: Long,
+
+    @field:NotEmpty
+    val title: String,
+
+    @field:NotEmpty
+    val content: String,
+
+    @field:NotNull
+    val artworkType: ArtworkType,
+
+    @field:NotNull
+    val tags: List<String>
+
+)

--- a/src/main/kotlin/com/novel/cloud/web/domain/artwork/service/ArtworkService.kt
+++ b/src/main/kotlin/com/novel/cloud/web/domain/artwork/service/ArtworkService.kt
@@ -5,6 +5,7 @@ import com.novel.cloud.db.entity.artwork.TemporaryArtwork
 import com.novel.cloud.web.config.security.context.MemberContext
 import com.novel.cloud.web.domain.artwork.controller.rq.CreateArtworkRq
 import com.novel.cloud.web.domain.artwork.controller.rq.AutoSaveTemporaryArtworkRq
+import com.novel.cloud.web.domain.artwork.controller.rq.UpdateArtworkRq
 import com.novel.cloud.web.domain.artwork.controller.rq.UpdateArtworkViewRq
 import com.novel.cloud.web.domain.artwork.repository.ArtworkRepository
 import com.novel.cloud.web.domain.artwork.repository.TemporaryArtworkRepository
@@ -46,6 +47,30 @@ class ArtworkService(
         artworkRepository.save(artwork)
         return artwork
     }
+
+    /**
+     * 작품 수정
+     */
+    fun updateArtwork(memberContext: MemberContext, rq: UpdateArtworkRq): Artwork {
+        val member = findMemberService.findLoginMemberOrElseThrow(memberContext)
+        val artwork = findArtworkService.findByIdOrElseThrow(rq.artworkId)
+
+        val tagContents = rq.tags.distinct()
+        val beforeTags = artwork.tags
+
+        val tags = artworkTagService.createTags(member, tagContents)
+
+        artwork.update(
+            title = rq.title,
+            content = rq.content,
+            artworkType = rq.artworkType,
+            tags = tags
+        )
+
+        artworkTagService.removeTags(member, beforeTags)
+        return artwork
+    }
+
 
     /**
      * 작품 조회수 증가

--- a/src/main/kotlin/com/novel/cloud/web/domain/file/controller/FileController.kt
+++ b/src/main/kotlin/com/novel/cloud/web/domain/file/controller/FileController.kt
@@ -21,7 +21,7 @@ class FileController(
     fun editorImageUpload(
         @RequestPart(value = "image") image: MultipartFile
     ): String {
-        FileValidateUtils.supportedFileValidationCheck(image)
+        FileValidateUtils.imageValidationCheck(image)
         return s3UploadService.upload(image)
     }
 

--- a/src/main/kotlin/com/novel/cloud/web/domain/file/service/FileService.kt
+++ b/src/main/kotlin/com/novel/cloud/web/domain/file/service/FileService.kt
@@ -78,4 +78,18 @@ class FileService(
         }
     }
 
+    /**
+     * 이미지 업데이트
+     */
+    fun updateArtworkImage(
+        memberContext: MemberContext,
+        artwork: Artwork,
+        thumbnail: MultipartFile,
+        multipartFiles: List<MultipartFile>
+    ) {
+        artwork.removeAttachFiles()
+        uploadThumbnail(artwork, thumbnail)
+        uploadImageFiles(artwork, multipartFiles)
+    }
+
 }

--- a/src/main/kotlin/com/novel/cloud/web/domain/file/service/FileService.kt
+++ b/src/main/kotlin/com/novel/cloud/web/domain/file/service/FileService.kt
@@ -87,9 +87,15 @@ class FileService(
         thumbnail: MultipartFile,
         multipartFiles: List<MultipartFile>
     ) {
-        artwork.removeAttachFiles()
+        deleteArtworkImages(artwork.attachFiles)
         uploadThumbnail(artwork, thumbnail)
         uploadImageFiles(artwork, multipartFiles)
+    }
+
+    private fun deleteArtworkImages(attachFiles: List<AttachFile>) {
+        attachFiles.map { attachFile ->
+            fileRepository.delete(attachFile)
+        }
     }
 
 }

--- a/src/main/kotlin/com/novel/cloud/web/domain/file/service/S3UploadService.kt
+++ b/src/main/kotlin/com/novel/cloud/web/domain/file/service/S3UploadService.kt
@@ -32,7 +32,7 @@ class S3UploadService(
      */
     @Throws(IOException::class)
     fun upload(file: MultipartFile): String {
-        val fileName = UUID.randomUUID().toString() + "-" + file.originalFilename
+        val fileName = UUID.randomUUID().toString()
         val objMeta = ObjectMetadata()
 
         val bytes = IOUtils.toByteArray(file.inputStream)
@@ -42,8 +42,10 @@ class S3UploadService(
 
         val byteArrayIs = ByteArrayInputStream(bytes)
 
-        s3Client.putObject(PutObjectRequest(bucket, dir + fileName, byteArrayIs, objMeta)
-            .withCannedAcl(CannedAccessControlList.PublicRead))
+        s3Client.putObject(
+            PutObjectRequest(bucket, dir + fileName, byteArrayIs, objMeta)
+                .withCannedAcl(CannedAccessControlList.PublicRead)
+        )
 
         val path = s3Client.getUrl(bucket, dir + fileName).path
         return urlToCloudFrontDomain(path)
@@ -52,7 +54,6 @@ class S3UploadService(
     fun urlToCloudFrontDomain(path: String): String {
         return cloudfrontDomain + path
     }
-
 
 
 }

--- a/src/main/kotlin/com/novel/cloud/web/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/novel/cloud/web/domain/member/controller/MemberController.kt
@@ -56,7 +56,7 @@ class MemberController(
         @AuthenticationPrincipal memberContext: MemberContext,
         @RequestPart(value = "profile") profile: MultipartFile,
     ) {
-        FileValidateUtils.supportedFileValidationCheck(profile)
+        FileValidateUtils.profileImageValidationCheck(profile)
         return memberService.updateMemberPicture(memberContext, profile)
     }
 

--- a/src/main/kotlin/com/novel/cloud/web/domain/tag/service/ArtworkTagService.kt
+++ b/src/main/kotlin/com/novel/cloud/web/domain/tag/service/ArtworkTagService.kt
@@ -30,11 +30,11 @@ class ArtworkTagService(
 
     fun removeTags(member: Member, beforeTags: List<Tag>) {
         beforeTags.map { tag ->
-            if (tag.usageCount > 1L) {
-                tag.minusUsageCount()
-            }
             if (tag.usageCount == 1L) {
                 artworkTagRepository.delete(tag)
+            }
+            if (tag.usageCount > 1L) {
+                tag.minusUsageCount()
             }
         }
     }

--- a/src/main/kotlin/com/novel/cloud/web/domain/tag/service/ArtworkTagService.kt
+++ b/src/main/kotlin/com/novel/cloud/web/domain/tag/service/ArtworkTagService.kt
@@ -18,15 +18,25 @@ class ArtworkTagService(
      */
     fun createTags(member: Member, tags: List<String>): List<Tag> {
         return tags.map { content ->
-            // 없으면 태그 생성
             val tag = findArtworkTagService.findByContentOrElseNull(content) ?: Tag(
                 content = content,
                 writer = member
             )
             artworkTagRepository.save(tag)
-            tag.updateUsageCount()
+            tag.plusUsageCount()
             tag
         }.toList()
+    }
+
+    fun removeTags(member: Member, beforeTags: List<Tag>) {
+        beforeTags.map { tag ->
+            if (tag.usageCount > 1L) {
+                tag.minusUsageCount()
+            }
+            if (tag.usageCount == 1L) {
+                artworkTagRepository.delete(tag)
+            }
+        }
     }
 
 }

--- a/src/main/kotlin/com/novel/cloud/web/exception/DoNotHavePermissionToDeleteOrUpdateArtworkException.kt
+++ b/src/main/kotlin/com/novel/cloud/web/exception/DoNotHavePermissionToDeleteOrUpdateArtworkException.kt
@@ -1,0 +1,6 @@
+package com.novel.cloud.web.exception
+
+import org.springframework.http.HttpStatus
+
+class DoNotHavePermissionToDeleteOrUpdateArtworkException
+    : GeneralHttpException(HttpStatus.FORBIDDEN, "댓글을 삭제하거나 수정할 수 있는 권한이 없습니다.", null)

--- a/src/main/kotlin/com/novel/cloud/web/path/ApiPath.kt
+++ b/src/main/kotlin/com/novel/cloud/web/path/ApiPath.kt
@@ -29,7 +29,7 @@ object ApiPath {
 
     const val VIEW_ARTWORK = "/api/artwork/view"
 
-    const val VIEW_UPDATE = "/api/artwork/view/update"
+    const val ARTWORK_UPDATE = "/api/artwork/update"
 
     const val ARTWORK_DETAIL = "/api/artwork/detail/{artworkId}"
 

--- a/src/main/kotlin/com/novel/cloud/web/path/ApiPath.kt
+++ b/src/main/kotlin/com/novel/cloud/web/path/ApiPath.kt
@@ -3,67 +3,69 @@ package com.novel.cloud.web.path
 object ApiPath {
 
     // 에러 핸들러
-    const val ERROR_AUTH = "/api/error"
+    const val ERROR_AUTH = "/api/v1/error"
 
     // 멤버
-    const val MEMBER = "/api/member"
+    const val MEMBER = "/api/v1/member"
 
-    const val MEMBER_SELF = "/api/member/self"
+    const val MEMBER_SELF = "/api/v1/member/self"
 
-    const val MEMBER_SELF_IMG = "/api/member/self/image"
+    const val MEMBER_SELF_IMG = "/api/v1/member/self/image"
 
-    const val MEMBER_SELF_NAME = "/api/member/self/nickname"
+    const val MEMBER_SELF_NAME = "/api/v1/member/self/nickname"
 
-    const val MEMBER_OTHER = "/api/member/profile/{memberId}"
+    const val MEMBER_OTHER = "/api/v1/member/profile/{memberId}"
 
-    const val LOGIN_OAUTH2 = "/api/oauth"
+    const val LOGIN_OAUTH2 = "/api/v1/oauth"
 
-    const val REFRESH_TOKEN = "/api/oauth/refresh"
+    const val REFRESH_TOKEN = "/api/v1/oauth/refresh"
 
     // 작품
-    const val ARTWORK = "/api/artwork"
+    const val ARTWORK = "/api/v1/artwork"
 
-    const val ARTWORK_SAVE = "/api/artwork/save"
+    const val ARTWORK_SAVE = "/api/v1/artwork/save"
 
-    const val ARTWORK_SUBMIT = "/api/artwork"
+    const val ARTWORK_SUBMIT = "/api/v1/artwork"
 
-    const val VIEW_ARTWORK = "/api/artwork/view"
+    const val VIEW_ARTWORK = "/api/v1/artwork/view"
 
-    const val ARTWORK_UPDATE = "/api/artwork/update"
+    const val ARTWORK_UPDATE = "/api/v1/artwork/update"
 
-    const val ARTWORK_DETAIL = "/api/artwork/detail/{artworkId}"
+    const val ARTWORK_DELETE = "/api/v1/artwork/delete"
+
+    const val ARTWORK_DETAIL = "/api/v1/artwork/detail/{artworkId}"
 
     // 파일
-    const val FILE = "/api/file"
+    const val FILE = "/api/v1/file"
 
-    const val FILE_UPLOAD = "/api/file/upload"
+    const val FILE_UPLOAD = "/api/v1/file/upload"
 
-    const val VIEW_ARTWORK_IMG = "/api/file/artwork/{fileUidName}"
+    const val VIEW_ARTWORK_IMG = "/api/v1/file/artwork/{fileUidName}"
 
-    const val VIEW_PROFILE_IMG = "/api/file/profile/{fileUidName}"
+    const val VIEW_PROFILE_IMG = "/api/v1/file/profile/{fileUidName}"
 
     // 단축어
-    const val SHORTCUT = "/api/shortcut"
+    const val SHORTCUT = "/api/v1/shortcut"
 
-    const val SHORTCUT_SEQUENCE = "/api/shortcut/sequence"
+    const val SHORTCUT_SEQUENCE = "/api/v1/shortcut/sequence"
 
     // 댓글
-    const val COMMENT = "/api/comment"
+    const val COMMENT = "/api/v1/comment"
 
-    const val VIEW_COMMENT = "/api/comment/{artworkId}"
+    const val VIEW_COMMENT = "/api/v1/comment/{artworkId}"
 
     // 좋아요
-    const val LIKE = "/api/like"
+    const val LIKE = "/api/v1/like"
 
-    const val TOGGLE_LIKE = "/api/like"
+    const val TOGGLE_LIKE = "/api/v1/like"
 
     // 검색
-    const val SEARCH = "/api/search"
+    const val SEARCH = "/api/v1/search"
 
-    const val SEARCH_TAG = "/api/search/tag"
+    const val SEARCH_TAG = "/api/v1/search/tag"
 
     // 태그
-    const val TAG = "/api/tag"
+    const val TAG = "/api/v1/tag"
 
 
 }

--- a/src/main/kotlin/com/novel/cloud/web/utils/DateUtils.kt
+++ b/src/main/kotlin/com/novel/cloud/web/utils/DateUtils.kt
@@ -13,8 +13,8 @@ object DateUtils {
         return Date()
     }
 
-    fun addTime(date: Date, millisecond: Long): Date {
-        return Date(date.time + millisecond)
+    fun addTime(date: Date, second: Long): Date {
+        return Date(date.time + (second * 1000))
     }
 
     fun formattedNow(): String {

--- a/src/main/kotlin/com/novel/cloud/web/utils/FileValidateUtils.kt
+++ b/src/main/kotlin/com/novel/cloud/web/utils/FileValidateUtils.kt
@@ -5,31 +5,49 @@ import org.springframework.web.multipart.MultipartFile
 
 object FileValidateUtils {
 
-    fun supportedFileValidationCheck(
+    fun imageValidationCheck(
         multipartFile: MultipartFile?
     ) {
         if (multipartFile == null || multipartFile.isEmpty) {
-            throw FileException("파일이 비어있습니다.")
+            throw FileException("이미지 파일이 비어있습니다.")
         }
+        if (multipartFile.size > 33554432) {
+            throw FileException("이미지 파일의 크기가 32MB를 넘습니다.")
+        }
+
         val contentType = multipartFile.contentType
         if (!isSupportedContentType(contentType)) {
             throw FileException("PNG, JPG, GIF만 허용됩니다.")
         }
     }
 
-    fun supportedFileValidationCheck(
+    fun imageValidationCheck(
         multipartFiles: List<MultipartFile>
     ) {
+        val totalFileSize = multipartFiles.sumOf { it.size }
+        if (totalFileSize > 209715200) {
+            throw FileException("전체 이미지 파일의 크기가 200MB를 넘습니다.")
+        }
+
         multipartFiles.map { multipartFile ->
-            if (multipartFile.isEmpty) {
-                throw FileException("파일이 비어있습니다.")
-            }
             val contentType = multipartFile.contentType
             if (!isSupportedContentType(contentType)) {
                 throw FileException("PNG, JPG, GIF만 허용됩니다.")
             }
         }
+    }
 
+    fun profileImageValidationCheck(profile: MultipartFile?) {
+        if (profile == null || profile.isEmpty) {
+            throw FileException("프로필 사진이 비어있습니다.")
+        }
+        if (profile.size > 5242880) {
+            throw FileException("프로필 사진의 크기가 5MB를 넘습니다.")
+        }
+        val contentType = profile.contentType
+        if (!isSupportedContentType(contentType)) {
+            throw FileException("PNG, JPG, GIF만 허용됩니다.")
+        }
     }
 
     private fun isSupportedContentType(contentType: String?): Boolean {


### PR DESCRIPTION
### 지라 이슈
[https://novel-cloud.atlassian.net/browse/NOVEL-69](https://novel-cloud.atlassian.net/browse/NOVEL-69)

- 작품 수정 기능
- 작품 삭제 기능 (tag 제외 cascade)
- v1으로 path 수정
- s3 업로드 시 original 파일 이름 포함 제거
- 이미지 없이 작품 업로드 가능하게 수정
- token 만료시간 millisecond을 second로 수정